### PR TITLE
@Input instead of @change

### DIFF
--- a/src/js/components/vue-file-base64.vue
+++ b/src/js/components/vue-file-base64.vue
@@ -1,6 +1,6 @@
 
 <template>
-  <input type="file" @change="onChange" :multiple="multiple" />
+  <input type="file" @input="onInput" :multiple="multiple" />
 </template>
 
 
@@ -30,7 +30,7 @@
     },
 
     methods: {
-      onChange(e){
+      onInput(e){
 
         // get the files
         let files = e.target.files;


### PR DESCRIPTION
Using @input is a safer way to have a trigger once the user selects a file. From my observation in Firefox, but I could be wrong, using change there can be a trigger also during the selection process (once the file selection window opens), before a file has actually been chosen